### PR TITLE
Fix money supply formula (s/21000/210000/)

### DIFF
--- a/lessons/ch2-14-sound-money.tex
+++ b/lessons/ch2-14-sound-money.tex
@@ -40,7 +40,7 @@ chose something more reliable than human restraint: mathematics.
 \begin{figure}
   \centering
   \begin{equation}
-  \sum\limits_{i=0}^{32} \frac{21000 \lfloor \frac{50*10^8}{2^i} \rfloor}{10^8}
+  \sum\limits_{i=0}^{32} \frac{210000 \lfloor \frac{50*10^8}{2^i} \rfloor}{10^8}
   \end{equation}
   \caption{Bitcoin's supply formula}
   \label{fig:supply-formula-white}


### PR DESCRIPTION
Due to a missing zero in the money supply formula, the result 'd be off by a factor 10, i.e. reaching ~2,1 million BTC instead of 21 million.

The halving happens every 210000 blocks:
https://github.com/bitcoin/bitcoin/blob/adf9bcfc37dbe93988588d1cfef8d9ee749be66f/src/chainparams.cpp#L67

On the online version of 21 Lessons, the formula is right:
https://github.com/21-lessons/21-lessons.github.io/blob/master/assets/images/supply-formula-white.png

Amazing book by the way, love it so far after having read the first 14 lessons, looking forward to read the third part 🚀 🚀 🚀 